### PR TITLE
Add support for Chronicle Regions 

### DIFF
--- a/ccib/__main__.py
+++ b/ccib/__main__.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
 
     falcon = FalconAPI()
     queue = Queue(maxsize=10)
-    chronicle = Chronicle(config.get('chronicle', 'customer_id'), config.get('chronicle', 'service_account'))
+    chronicle = Chronicle(config.get('chronicle', 'customer_id'), config.get('chronicle', 'service_account'),config.get('chronicle','region'))
 
     FalconReaderThread(falcon, queue).start()
     ChronicleWriterThread(queue, chronicle).start()

--- a/ccib/chronicle.py
+++ b/ccib/chronicle.py
@@ -10,15 +10,33 @@ from google.oauth2 import service_account
 class Chronicle:
     OAUTH2_SCOPES = ['https://www.googleapis.com/auth/chronicle-backstory',
                      'https://www.googleapis.com/auth/malachite-ingestion']
-    INGEST_ENDPOINT = 'https://malachiteingestion-pa.googleapis.com/v2/unstructuredlogentries:batchCreate'
+    
 
-    def __init__(self, customer_id, service_account_file):
+    def __init__(self, customer_id, service_account_file,region):
         self.customer_id = customer_id
+        self.region = region
         # Create a credential using Google Developer Service Account Credential and Chronicle # API Scope.
         self.credentials = service_account.Credentials.from_service_account_file(
             service_account_file, scopes=self.OAUTH2_SCOPES)
         # Build an HTTP session to make authorized OAuth requests.
         self.http_session = requests.AuthorizedSession(self.credentials)
+        # https://cloud.google.com/chronicle/docs/reference/search-api#regional_endpoints
+        # https://cloud.google.com/chronicle/docs/reference/ingestion-api#regional_endpoints
+        # select region
+        match self.region:
+            case "EU":
+                self.INGEST_ENDPOINT = 'https://europe-malachiteingestion-pa.googleapis.com/v2/unstructuredlogentries:batchCreate'
+            case "UK":
+                self.INGEST_ENDPOINT = 'https://europe-west2-malachiteingestion-pa.googleapis.com/v2/unstructuredlogentries:batchCreate'            
+            case "IL":
+                self.INGEST_ENDPOINT = 'https://me-west1-malachiteingestion-pa.googleapis.com/v2/unstructuredlogentries:batchCreate'
+            case "AU":
+                self.INGEST_ENDPOINT = 'https://australia-southeast1-malachiteingestion-pa.googleapis.com/v2/unstructuredlogentries:batchCreate'                      
+            case "SG":
+                self.INGEST_ENDPOINT = 'https://asia-southeast1-malachiteingestion-pa.googleapis.com/v2/unstructuredlogentries:batchCreate'
+            case _:
+                self.INGEST_ENDPOINT = 'https://malachiteingestion-pa.googleapis.com/v2/unstructuredlogentries:batchCreate'
+
 
     def send_indicators(self, indicators):
         ts = int(datetime.datetime.utcnow().timestamp() * 1000000)

--- a/ccib/config.py
+++ b/ccib/config.py
@@ -2,7 +2,7 @@ import os
 import configparser
 
 
-class FigConfig(configparser.SafeConfigParser):
+class FigConfig(configparser.ConfigParser):
     FALCON_CLOUD_REGIONS = {'us-1', 'us-2', 'eu-1', 'us-gov-1'}
     ENV_DEFAULTS = [
         ['logging', 'level', 'LOG_LEVEL'],


### PR DESCRIPTION
These commits enable the program to use the chronicle.region config argument as intended, region endpoints are based on https://cloud.google.com/chronicle/docs/reference/ingestion-api#regional_endpoints (this documentation is out of date however and does not contain the Australia endpoint, which is referencable from the search api documentation) 

Also removes SafeConfigParser reference, this is an alias class for ConfigParser and no longer  exists in the python version installed through the base image https://github.com/python/cpython/blob/cd90f6a3692e0f7ef0a13aae651e19a08d1f9b31/Lib/configparser.py#L1230
