### PR TITLE
fix: implement better handling of potential connection errors

### DIFF
--- a/ccib/chronicle.py
+++ b/ccib/chronicle.py
@@ -56,5 +56,10 @@ class Chronicle:
             'log_type': "CROWDSTRIKE_IOC",
             'entries': entries,
         }
-        response = self.http_session.post(self.ingest_endpoint, json=body)
+        # Add explicit timeouts to prevent hanging connections
+        response = self.http_session.post(
+            self.ingest_endpoint,
+            json=body,
+            timeout=(10, 30)  # (connect timeout, read timeout) in seconds
+        )
         response.raise_for_status()

--- a/ccib/threads.py
+++ b/ccib/threads.py
@@ -71,6 +71,17 @@ class ChronicleWriterThread(threading.Thread):
                 self.chronicle.send_indicators(batch)
                 return
             except Exception:  # pylint: disable=W0703
-                log.exception("Error occurred while processing indicators batch")
-                time.sleep(i)
+                log.exception("Error occurred while processing indicators batch (attempt %d/30)", i+1)
+                # Use exponential backoff with a maximum delay of 60 seconds
+                backoff_seconds = min(2 ** i, 60)
+                log.info("Retrying in %d seconds...", backoff_seconds)
+                time.sleep(backoff_seconds)
+
+                # For persistent failures, recreate the session
+                if i == 5:
+                    log.info("Recreating HTTP session...")
+                    # Refresh the session to handle potential stale connections
+                    from google.auth.transport import requests
+                    self.chronicle.http_session = requests.AuthorizedSession(self.chronicle.credentials)
+
         log.critical("Could not transmit indicators to Chronicle")

--- a/ccib/threads.py
+++ b/ccib/threads.py
@@ -1,5 +1,6 @@
 import threading
 import time
+from google.auth.transport import requests
 from .icache import icache
 from .config import config
 from .log import log
@@ -81,7 +82,6 @@ class ChronicleWriterThread(threading.Thread):
                 if i == 5:
                     log.info("Recreating HTTP session...")
                     # Refresh the session to handle potential stale connections
-                    from google.auth.transport import requests
                     self.chronicle.http_session = requests.AuthorizedSession(self.chronicle.credentials)
 
         log.critical("Could not transmit indicators to Chronicle")


### PR DESCRIPTION
This PR introduces some changes to how we can better deal with network instability, firewall interruptions, or server-side issues to prevent having to restart the container. Some changes to help:
- Added timeouts to prevent hanging connections
- Use exponential backoff retries when network issues may arise
- If after 5 failed retries, try recreating the HTTP session